### PR TITLE
test : api 라우터 테스트

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "prettier", "react-hooks"],
+  "plugins": ["@typescript-eslint", "prettier"],
   "parserOptions": {
     "project": "./tsconfig.json",
     "createDefaultProgram": true
@@ -24,6 +24,7 @@
     "react/react-in-jsx-scope": "off",
     "react/jsx-filename-extension": ["warn", { "extensions": [".ts", ".tsx"] }],
     "no-useless-catch": "off",
-    "react-hooks/rules-of-hooks": "error"
+    "react-hooks/rules-of-hooks": "error",
+    "import/prefer-default-export": "off"
   }
 }

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request) {
+  const res = await request.json();
+  return NextResponse.json({ res });
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,21 +1,25 @@
 "use client";
 
 import { Button, Form, Input, Select } from "antd";
+import axios from "axios";
 import React from "react";
 
 const { Option } = Select;
 
 export default function Page() {
   const [form] = Form.useForm();
-  const onFinish = values => {
+  async function onFinish(values) {
     console.log("Received values of form: ", values);
-  };
+    axios
+      .post("/api/register", values) //
+      .then(res => console.log(res));
+  }
 
   return (
     <Form
       form={form}
       name="register"
-      onFinish={onFinish}
+      onFinish={() => onFinish}
       style={{
         width: "100%",
         height: "100vh",


### PR DESCRIPTION
앱 라우터에서도 api 라우터가 작동하는지 기능테스트

✅앱 라우터는 페이지 라우터와 다른점이 있기 때문에 기존의 페이지 라우터와 다르게 함수를 작성해야 api 라우팅 구현이 가능합니다.
/app/api/register/route.ts 파일 생성 후에, 
/app/register/page.tsx에서 회원등록 post 요청 시 위의 경로에 있는 파일에서 response을 정상으로 출력하는지 테스트했습니다.

✅"ESLint couldn't determine the plugin 'react-hooks' uniquely." 오류 해결을 위해서 .eslintrc.json 에 있는 plugin에서 react-hooks 제거했습니다.
✅"import/prefer-default-export" 규칙 (default export를 선호하는 규칙) 을 변경하기 위해  .eslintrc.json에 규칙을 추가했습니다.