### PR TITLE
feat: goal-list 페이지에서 goal 클릭시 detail/[id] 페이지로 라우팅

### DIFF
--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function GoalDetailPage() {
+  return <div>목표 상세 페이지</div>;
+}

--- a/app/goal-list/page.tsx
+++ b/app/goal-list/page.tsx
@@ -7,6 +7,7 @@ import goalImage from "/public/images/goalImage.png";
 import Image from "next/image";
 import { LeftOutlined, RightOutlined } from "@ant-design/icons";
 import { Button, Space } from "antd";
+import Link from "next/link";
 
 const contentStyle: React.CSSProperties = {
   margin: 0,
@@ -17,6 +18,9 @@ const contentStyle: React.CSSProperties = {
 };
 
 interface GoalItemType {
+  id: {
+    goalId: string;
+  };
   snippet: {
     title: string;
   };
@@ -66,18 +70,20 @@ export default function GoalPage() {
       >
         {goal.map((item, i) => (
           <div>
-            <h3 style={contentStyle}>
-              <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
-                <Image
-                  src={goalImage}
-                  alt="image1"
-                  width="400"
-                  height="400"
-                  style={{ marginTop: "20px" }}
-                />
-              </div>
-              {goal.length > 0 && <span>{goal[i].snippet.title}</span>}
-            </h3>
+            <Link href={`/detail/${goal[i].id.goalId}`}>
+              <h3 style={contentStyle}>
+                <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+                  <Image
+                    src={goalImage}
+                    alt="image1"
+                    width="400"
+                    height="400"
+                    style={{ marginTop: "20px" }}
+                  />
+                </div>
+                {goal.length > 0 && <span>{goal[i].snippet.title}</span>}
+              </h3>
+            </Link>
           </div>
         ))}
       </Carousel>

--- a/public/data/goal.json
+++ b/public/data/goal.json
@@ -7,7 +7,7 @@
       "etag": "iuXeoSQwO2BaagdDSINgUbc",
       "id": {
         "kind": "onehour#goal",
-        "noticeId": "eIh2S0ZzahI"
+        "goalId": "a"
       },
       "snippet": {
         "publishedAt": "2023.07.13",
@@ -21,7 +21,7 @@
       "etag": "SQwO2BaagdDSINgUbc",
       "id": {
         "kind": "onehour#goal",
-        "noticeId": "eIh2ZzahI"
+        "goalId": "b"
       },
       "snippet": {
         "publishedAt": "2023.07.12",
@@ -35,7 +35,7 @@
       "etag": "iasavzvvvziUbc",
       "id": {
         "kind": "onehour#goal",
-        "noticeId": "eIassdhkklZzahI"
+        "goalId": "c"
       },
       "snippet": {
         "publishedAt": "2023.07.10",
@@ -49,7 +49,7 @@
       "etag": "iuXeoSQwO2BaagdDSkafafad",
       "id": {
         "kind": "onehour#goal",
-        "noticeId": "eIh2S0ZzahI"
+        "goalId": "d"
       },
       "snippet": {
         "publishedAt": "2023.07.11",


### PR DESCRIPTION
추가 기능 : goal-list 페이지에서 각 goal 클릭시 해당 id에 맞게 detail/[id] 페이지로 라우팅 구현
