### PR TITLE
hotfix : defaultProps 오류해결

### DIFF
--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -1,26 +1,18 @@
-"use client";
-
 import { Button as AntButton } from "antd";
 
 interface ButtonProps {
-  danger?: boolean;
-  type?: "primary" | "ghost" | "dashed" | "link" | "text" | "default";
+  danger: boolean;
+  type: "primary" | "ghost" | "dashed" | "link" | "text" | "default";
   text: string;
-  onClick?: () => void;
+  onClick: () => void;
 }
 
-function Button({ danger, type, text, onClick }: ButtonProps) {
+function Button({ danger = false, type = "default", text, onClick }: ButtonProps) {
   return (
     <AntButton type={type} size="large" onClick={onClick} danger={danger}>
       {text}
     </AntButton>
   );
 }
-
-Button.defaultProps = {
-  danger: false,
-  type: "default",
-  onClick: () => {},
-};
 
 export default Button;


### PR DESCRIPTION
React 함수 컴포넌트의 defaultProps 지원 종료 예정
interface에 ButtonProps 직접 명시로 해결