### PR TITLE
chore : eslintrc 문서 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,8 @@
     "react/react-in-jsx-scope": "off",
     "react/jsx-filename-extension": ["warn", { "extensions": [".ts", ".tsx"] }],
     "no-useless-catch": "off",
-    "react-hooks/rules-of-hooks": "error"
+    "react-hooks/rules-of-hooks": "error",
+    "react/prop-types": "off", // PropTypes 검사 비활성화
+    "react/require-default-props": "off" // defaultProps 요구 규칙 비활성화
   }
 }

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -1,21 +1,17 @@
 import { Button as AntButton } from "antd";
 
 interface ButtonProps {
-  type: "primary" | "ghost" | "dashed" | "link" | "text" | "default";
+  type?: "primary" | "ghost" | "dashed" | "link" | "text" | "default";
   text: string;
   onClick?: () => void;
 }
 
-function Button({ type = "default", text, onClick }: ButtonProps) {
+function Button({ type = "default", text, onClick }: ButtonProps = { text: "" }) {
   return (
     <AntButton type={type} size="large" onClick={onClick} className="bg-button-color font-black">
       {text}
     </AntButton>
   );
 }
-
-Button.defaultProps = {
-  onClick: () => {}, // 기본값으로 빈 함수를 지정하거나, 필요에 따라 다른 기본 동작을 설정할 수 있습니다.
-};
 
 export default Button;


### PR DESCRIPTION
커밋 시, eslint의 propsType 검사와 defaultProps 요구 규칙 비활성 
defaultProps을 사용하면 함수 컴포넌트에서 오류가 생기기 때문에 비활성화 했습니다.